### PR TITLE
Inclusion of default data to config_rulesets to forward to NCSA's…

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -84,6 +84,21 @@ profile_rsyslog::config_rulesets:
           facility: "local7.*"
           config:
             file: "/var/log/boot.log"
+      - action:
+          name: "syslog-security-relp"
+          type: "omrelp"
+          config:
+            target: "syslog.security.ncsa.illinois.edu"
+            port: "1514"
+            queue.FileName: "syslog-security-buffer"
+            queue.SaveOnShutdown: "on"
+            queue.Type: "LinkedList"
+            queue.size: "1000000"
+            queue.maxdiskspace: "10000000000"
+            queue.syncqueuefiles: "on"
+            Action.ResumeInterval: "30"
+            Action.ResumeRetryCount: "-1"
+            timeout: "6"
 profile_rsyslog::config_templates: {}
 profile_rsyslog::feature_packages:
   - "rsyslog-relp"


### PR DESCRIPTION
…default security loghost

Leaving the example in the README to be pretty generic (as far as the loghost hostnames), but add in the the hiera data to config_rulesets to forward to NCSA’s default security loghost. This could this cause a problem if a host doesn't have a route for the data to reach security's loghost -- e.g. something like "fills local drive". But then it should probably be using a custom control-template that has the correct settings in it, and "out of space" would be a sign that puppet hiera was missing that customization.