### PR TITLE
SECURITY-1298: update default parameters to not listen via tcp, udp, …

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ then forward them to a central log host.
 
 ```
 ---
+profile_rsyslog::config_inputs:
+  imtcp:
+    type: "imtcp"
+    config:
+      port: 514
+      Ruleset: "local_messages"
+  imudp:
+    type: "imudp:"
+    config:
+      port: 514
+      Ruleset: "local_messages"
+  imrelp:
+    type: "imrelp"
+    config:
+      port: 20515
+      Ruleset: "local_messages"
 profile_rsyslog::config_rulesets:
   local_messages:
     rules:

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,22 +12,7 @@ profile_rsyslog::config_global:
     value: "on"
   maxMessageSize:
     value: "64k"
-profile_rsyslog::config_inputs:
-  imtcp:
-    type: "imtcp"
-    config:
-      port: 514
-      Ruleset: "local_messages"
-  imudp:
-    type: "imudp:"
-    config:
-      port: 514
-      Ruleset: "local_messages"
-  imrelp:
-    type: "imrelp"
-    config:
-      port: 20515
-      Ruleset: "local_messages"
+profile_rsyslog::config_inputs: {}
 profile_rsyslog::config_modules:
   omrelp: {}
   imuxsock:


### PR DESCRIPTION
…or relp

Update default parameters to not listen via tcp, udp, or relp
Add config::inputs example for Relay server to README to include listener