### PR TITLE
log_dir needs to be an array

### DIFF
--- a/manifests/collector.pp
+++ b/manifests/collector.pp
@@ -116,7 +116,7 @@ class profile_rsyslog::collector (
     include profile_backup::client
 
     profile_backup::client::add_job { 'rsyslog_collector':
-      paths            => $log_dir,
+      paths            => [$log_dir,],
     }
   }
 }


### PR DESCRIPTION
I fixed this previously and I must have reverted to a previous revision. Either way. This fix is tested.